### PR TITLE
NPM command to generate a zip of the plugin files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+wpcom-migration-plugin.zip
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "wpcom-migration",
+	"scripts": {
+		"test": "echo \"Error: no test specified\" && exit 1",
+		"create-zip": "zip -r -o wpcom-migration-plugin.zip src/*"
+	}
+}


### PR DESCRIPTION
This adds the command `npm run create-zip` to quickly create a zip of the plugin files. This is useful if you want to checkout the files locally to test (rather than downloading a zip from Github).

# Testing

* Checkout this branch locally.
* Run `npm run create-zip`.
* Verify that the file `wpcom-migration-plugin.zip` is created and can be uploaded & activated on a WordPress site.