### PR TITLE
Add the static verifying-info screen

### DIFF
--- a/src/static/assets/css/style.css
+++ b/src/static/assets/css/style.css
@@ -66,6 +66,14 @@
 	max-width: 436px;
 }
 
+.wpcom-migration-content-full-width {
+	width: 100%;
+}
+
+.wpcom-migration-content-full-width h1 {
+	text-align: center;
+}
+
 /*
  * Sidebar
  */
@@ -210,6 +218,69 @@ input:has(+ .wpcom-migration-input-info) {
 	width: 16px;
 	height: 16px;
 	margin-left: 8px;
+}
+
+/**
+ * Loading Ellipsis
+ */
+ .wpcom-migration__loading-ellipsis {
+	display: inline-block;
+	position: relative;
+	width: 80px;
+	height: 80px;
+	left: 45%;
+
+	> div {
+		position: absolute;
+		top: 33px;
+		width: 13px;
+		height: 13px;
+		border-radius: 50%;
+		background: var(--wpcom-migration-gray-60);
+		animation-timing-function: cubic-bezier(0, 1, 1, 0);
+
+		&:nth-child(1) {
+			left: 8px;
+			animation: wpcom-migration__loading-ellipsis-grow 0.6s infinite;
+		}
+		&:nth-child(2) {
+			left: 8px;
+			animation: wpcom-migration__loading-ellipsis-move 0.6s infinite;
+		}
+		&:nth-child(3) {
+			left: 32px;
+			animation: wpcom-migration__loading-ellipsis-move 0.6s infinite;
+		}
+		&:nth-child(4) {
+			left: 56px;
+			animation: wpcom-migration__loading-ellipsis-shrink 0.6s infinite;
+		}
+	}
+ }
+
+ @keyframes wpcom-migration__loading-ellipsis-grow {
+	0% {
+		transform: scale(0);
+	}
+	100% {
+		transform: scale(1);
+	}
+}
+@keyframes wpcom-migration__loading-ellipsis-move {
+	0% {
+		transform: translate(0, 0);
+	}
+	100% {
+		transform: translate(24px, 0);
+	}
+}
+@keyframes wpcom-migration__loading-ellipsis-shrink {
+	0% {
+		transform: scale(1);
+	}
+	100% {
+		transform: scale(0);
+	}
 }
 
 /**

--- a/src/static/verifying.php
+++ b/src/static/verifying.php
@@ -1,0 +1,21 @@
+<header class="wpcom-migration-header">
+	<div class="wpcom-migration-header__wpcom-logo">
+		<span class="dashicons dashicons-wordpress-alt"></span>
+	</div>
+
+	<div class="wpcom-migration-header__blogvault-logo">
+		<img src="<?php echo esc_url( plugins_url('../assets/img/blogvault-logo.png', __FILE__ ) ); ?>" alt="blogvault-logo">
+	</div>
+</header>
+
+<div class="wpcom-migration-container">
+	<main class="wpcom-migration-content-full-width">
+		<h1>Verifying your information</h1>
+		<div class="wpcom-migration__loading-ellipsis">
+				<div></div>
+				<div></div>
+				<div></div>
+				<div></div>
+		</div>
+	</main>
+</div>


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/8726

This adds the "Verifying your information" static page with loading icon.

# Screenshots

Desktop:
<img width="1254" alt="CleanShot 2024-08-16 at 13 30 36@2x" src="https://github.com/user-attachments/assets/554bac7a-c642-4ae5-a131-fad97fcd5752">

Mobile:
<img width="517" alt="CleanShot 2024-08-16 at 13 30 59@2x" src="https://github.com/user-attachments/assets/33d66e8f-63b5-4f68-a5c4-67b0b9872e61">

# Testing Instructions
1. [Download](https://download-directory.github.io/?url=https%3A%2F%2Fgithub.com%2Fblogvault%2Fwpcom-migration%2Ftree%2F8726-update%2Fverify-info-screen%2Fsrc) and install the plugin. You could use [jurassic.ninja](https://jurassic.ninja/) for a quick environment setup.
2. Go to `/wp-admin/admin.php?page=automattic&static=verifying`.
3. Compare the page to the [design](https://www.figma.com/design/c9jLiGBEqrxgEpHc8ccVFr/WP.com-migration-plugin-screen-designs?node-id=163-411&t=E27OyiNeJR3nqdoN-0). Having small differences should be fine, IMO.
4. Make sure it looks good on mobile and the different browsers.