### PR TITLE
Add static migration details screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 wpcom-migration-plugin.zip
 .DS_Store
+.idea

--- a/src/static/assets/css/style.css
+++ b/src/static/assets/css/style.css
@@ -34,6 +34,7 @@
 	gap: 40px;
 	font-size: 14px;
 	color: var( --wpcom-migration-gray-70 );
+	text-underline-offset: 4px;
 }
 
 .wpcom-migration-container > * {
@@ -43,6 +44,10 @@
 .wpcom-migration-container p {
 	margin: 8px 0;
 	font-size: inherit;
+}
+
+.wpcom-migration-container a:hover {
+	color: var( --wpcom-migration-link-hover-color );
 }
 
 .wpcom-migration-container h1 {
@@ -66,15 +71,16 @@
  */
 .wpcom-migration-sidebar {
 	max-width: 340px;
-	padding: 40px;
-	border-radius: 4px;
-	background: var( --wpcom-migration-secondary-bg );
-	color: #000;
 }
 
 .wpcom-migration-sidebar p {
+	color: var( --wpcom-migration-gray-80 );
 	font-size: 12px;
 	line-height: 20px;
+}
+
+.wpcom-migration-sidebar a {
+	color: var( --wpcom-migration-gray-80 );
 }
 
 .wpcom-migration-sidebar h3 {
@@ -84,6 +90,17 @@
 	font-size: 20px;
 	font-weight: 500;
 	line-height: 1.3;
+}
+
+.wpcom-migration-sidebar__inner {
+	padding: 40px;
+	border-radius: 4px;
+	color: #000;
+	background: var( --wpcom-migration-secondary-bg );
+}
+
+.wpcom-migration-sidebar__inner p {
+	color: #000;
 }
 
 /*
@@ -108,6 +125,9 @@
 .wpcom-migration-input-group {
 	display: flex;
 	flex-direction: column;
+}
+
+.wpcom-migration-input-group + .wpcom-migration-input-group {
 	margin-top: 16px;
 }
 
@@ -131,13 +151,7 @@
 
 .wpcom-migration-input-group input[type='checkbox'] {
 	flex: none;
-	margin: 0;
-}
-
-.wpcom-migration-input-group--checkbox {
-	flex-direction: row;
-	align-items: center;
-	gap: 12px;
+	margin: 0 12px 0 0;
 }
 
 .wpcom-migration-input-group--checkbox label {
@@ -146,12 +160,18 @@
 	line-height: 20px;
 }
 
-.wpcom-migration-input-group--checkbox label a {
+.wpcom-migration-input-group--checkbox a {
 	color: var( --wpcom-migration-gray-60 );
 }
 
-.wpcom-migration-input-group--checkbox label a:hover {
-	color: var( --wpcom-migration-link-hover-color );
+.wpcom-migration-input-info {
+	background: var( --wpcom-migration-gray-0 );
+	padding: 11px 16px;
+	border-radius: 0 0 2px 2px;
+}
+
+input:has(+ .wpcom-migration-input-info) {
+	border-radius: 2px 2px 0 0;
 }
 
 /*
@@ -193,11 +213,82 @@
 }
 
 /**
- * Misc
+ * Foldable
+ */
+.wpcom-migration-foldable__header {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	cursor: pointer;
+}
+
+.wpcom-migration-foldable__header:after {
+	content: "\f347";
+	font-family: dashicons;
+	font-size: 18px;
+}
+
+.wpcom-migration-foldable--expanded .wpcom-migration-foldable__header:after {
+	content: "\f343";
+}
+
+.wpcom-migration-foldable__title {
+	font-size: 16px;
+	font-weight: 500;
+	line-height: 24px;
+	color: var( --wpcom-migration-gray-80 );
+}
+
+.wpcom-migration-foldable__description {
+	line-height: 20px;
+	color: var( --wpcom-migration-gray-50 );
+}
+
+.wpcom-migration-foldable__body {
+	display: none;
+}
+
+.wpcom-migration-foldable--expanded .wpcom-migration-foldable__body {
+	display: block;
+}
+
+/**
+ * Section
  */
 .wpcom-migration-section {
 	margin-top: 24px;
 }
+
+.wpcom-migration-section__title {
+	margin-top: 8px;
+	color: #000;
+	font-weight: 500;
+	line-height: 20px;
+}
+
+.wpcom-migration-section__description {
+	color: var( --wpcom-migration-gray-50 );
+	font-size: 12px;
+	line-height: 20px;
+}
+
+.wpcom-migration-section__inner {
+	padding: 12px 16px;
+	margin-top: 8px;
+	border-radius: 4px;
+	background: var( --wpcom-migration-gray-0 );
+}
+
+.wpcom-migration-section__inner .wpcom-migration-input-group--checkbox {
+	max-height: 200px;
+	padding-left: 1px;
+	gap: 16px;
+	overflow: auto;
+}
+
+/**
+ * Misc
+ */
 
 /* Fix main content having extra padding on mobile. */
 .toplevel_page_automattic.auto-fold #wpcontent {

--- a/src/static/assets/css/variables.css
+++ b/src/static/assets/css/variables.css
@@ -2,9 +2,12 @@
 	--wpcom-migration-heading-font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
 	--wpcom-migration-primary-bg: #3858e9;
 	--wpcom-migration-secondary-bg: #eff1fc;
+	--wpcom-migration-gray-0: #f6f7f7;
 	--wpcom-migration-gray-10: #c3c4c7;
+	--wpcom-migration-gray-50: #646970;
 	--wpcom-migration-gray-60: #50575e;
 	--wpcom-migration-gray-70: #3c434a;
+	--wpcom-migration-gray-80: #2c3338;
 	--wpcom-migration-gray-100: #101517;
 	--wpcom-migration-link-hover-color: #135e96;
 }

--- a/src/static/assets/js/app.js
+++ b/src/static/assets/js/app.js
@@ -1,0 +1,23 @@
+( function () {
+	const toggleFoldable = function ( foldableElement ) {
+		foldableElement.classList.toggle('wpcom-migration-foldable--expanded');
+	}
+
+	const checkInputGroupCheckboxes = function ( inputGroupElement, checked ) {
+		inputGroupElement.querySelectorAll( 'input[type="checkbox"]' ).forEach( ( checkboxElement ) => {
+			checkboxElement.checked = checked;
+		} );
+	}
+
+	document.querySelectorAll( '.wpcom-migration-foldable__header' ).forEach( ( element ) => {
+		element.addEventListener( 'click', () => toggleFoldable( element.parentElement ) );
+	} );
+
+	document.querySelectorAll( 'input.wpcom-migration-select-all' ).forEach( ( checkboxElement ) => {
+		checkboxElement.addEventListener( 'change', () => {
+			const inputGroupElement = checkboxElement.closest( '.wpcom-migration-input-group' );
+
+			checkInputGroupCheckboxes( inputGroupElement, checkboxElement.checked );
+		} );
+	} );
+} )();

--- a/src/static/main.php
+++ b/src/static/main.php
@@ -17,12 +17,13 @@
 			<div class="wpcom-migration-section">
 				<div class="wpcom-migration-input-group">
 					<label for="wpcom-migration-email">Email address</label>
-					<input type="text" placeholder="Enter your email address for updates" id="wpcom-migration-email">
+					<input type="email" placeholder="Enter your email address for updates" id="wpcom-migration-email" required>
 				</div>
 
 				<div class="wpcom-migration-input-group wpcom-migration-input-group--checkbox">
-					<input type="checkbox" id="wpcom-migration-terms">
-					<label for="wpcom-migration-terms">I agree to BlogVault’s <a href="">Terms & Conditions</a> and <a href="">Privacy Policy</a></label>
+					<label>
+						<input type="checkbox" id="wpcom-migration-terms" required> I agree to BlogVault’s <a href="">Terms & Conditions</a> and <a href="">Privacy Policy</a>
+					</label>
 				</div>
 			</div>
 
@@ -33,14 +34,16 @@
 	</main>
 
 	<aside class="wpcom-migration-sidebar">
-		<h3>Let us migrate your site for free</h3>
-		<p>Sit back and our experts will migrate your site for you. You'll get 50% off your first year, and you'll be up and running in no more than 2 business days.</p>
+		<div class="wpcom-migration-sidebar__inner">
+			<h3>Let us migrate your site for free</h3>
+			<p>Sit back and our experts will migrate your site for you. You'll get 50% off your first year, and you'll be up and running in no more than 2 business days.</p>
 
-		<a class="wpcom-migration-cta-link" href="https://wordpress.com/move/" target="_blank">Get your Free migration</a>
+			<a class="wpcom-migration-cta-link" href="https://wordpress.com/move/" target="_blank">Get your Free migration</a>
 
-		<div class="wpcom-migration-testimonial">
-			<div class="wpcom-migration-testimonial__text">Loved by our customers</div>
-			<img class="wpcom-migration-testimonial__image" src="<?php echo esc_url( plugins_url('../static/assets/images/testimonial.png', __FILE__ ) ); ?>" alt="testimonial" />
+			<div class="wpcom-migration-testimonial">
+				<div class="wpcom-migration-testimonial__text">Loved by our customers</div>
+				<img class="wpcom-migration-testimonial__image" src="<?php echo esc_url( plugins_url('../static/assets/images/testimonial.png', __FILE__ ) ); ?>" alt="testimonial" />
+			</div>
 		</div>
 	</aside>
 </div>

--- a/src/static/start.php
+++ b/src/static/start.php
@@ -1,0 +1,130 @@
+<header class="wpcom-migration-header">
+	<div class="wpcom-migration-header__wpcom-logo">
+		<span class="dashicons dashicons-wordpress-alt"></span>
+	</div>
+
+	<div class="wpcom-migration-header__blogvault-logo">
+		<img src="<?php echo esc_url( plugins_url('../assets/img/blogvault-logo.png', __FILE__ ) ); ?>" alt="blogvault-logo">
+	</div>
+</header>
+
+<div class="wpcom-migration-container">
+	<main class="wpcom-migration-content">
+		<h1>Start your migration</h1>
+		<p>Let's get started. Just drop your migration key below, customize your options in Advanced Settings, and you're all set.</p>
+
+		<form class="wpcom-migration-form">
+			<div class="wpcom-migration-section">
+				<div class="wpcom-migration-input-group">
+					<label for="wpcom-migration-key">Migration Key</label>
+					<input type="text" placeholder="Enter your migration key" id="wpcom-migration-key" required>
+					<div class="wpcom-migration-input-info">
+						Need a migration key? <a href="" target="_blank">Get it on WordPress.com</a>
+					</div>
+				</div>
+			</div>
+
+			<div class="wpcom-migration-section wpcom-migration-foldable">
+				<div class="wpcom-migration-foldable__header">
+					<div class="wpcom-migration-foldable__header-content">
+						<div class="wpcom-migration-foldable__title">Advanced options</div>
+						<div class="wpcom-migration-foldable__description">Add additional credentials or customize your migration.</div>
+					</div>
+				</div>
+
+				<div class="wpcom-migration-foldable__body">
+					<div class="wpcom-migration-section">
+						<div class="wpcom-migration-section__title">Source site credentials</div>
+						<div class="wpcom-migration-section__description">Provide the following credentials if this site is password protected.</div>
+						<div class="wpcom-migration-section__inner">
+							<div class="wpcom-migration-input-group">
+								<label for="wpcom-migration-username">Username</label>
+								<input type="text" placeholder="Enter your username" id="wpcom-migration-username">
+							</div>
+
+							<div class="wpcom-migration-input-group">
+								<label for="wpcom-migration-password">Password</label>
+								<input type="text" placeholder="Enter your password" id="wpcom-migration-password">
+							</div>
+						</div>
+					</div>
+
+					<div class="wpcom-migration-section">
+						<div class="wpcom-migration-section__title">Customize migration</div>
+						<div class="wpcom-migration-section__description">Pick the tables and folders you would like to migrate.</div>
+
+						<div class="wpcom-migration-section__title">Folders</div>
+						<div class="wpcom-migration-section__inner">
+							<div class="wpcom-migration-input-group wpcom-migration-input-group--checkbox">
+								<label>
+									<input type="checkbox" checked disabled> ./wp-admin/
+								</label>
+								<label>
+									<input type="checkbox" checked disabled> ./wp-content/
+								</label>
+								<label>
+									<input type="checkbox" checked disabled> ./wp-includes/
+								</label>
+								<label>
+									<input type="checkbox"> ./.private/
+								</label>
+							</div>
+						</div>
+
+						<div class="wpcom-migration-section__title">Database tables</div>
+						<div class="wpcom-migration-section__inner">
+							<div class="wpcom-migration-input-group wpcom-migration-input-group--checkbox">
+								<label>
+									<input class="wpcom-migration-select-all" type="checkbox"> Select All
+								</label>
+								<label>
+									<input type="checkbox"> wp_bv_activities_store
+								</label>
+								<label>
+									<input type="checkbox" checked> wp_commentmeta
+								</label>
+								<label>
+									<input type="checkbox" checked> wp_comments
+								</label>
+								<label>
+									<input type="checkbox" checked> wp_jetpack_sync_queue
+								</label>
+								<label>
+									<input type="checkbox" checked> wp_links
+								</label>
+								<label>
+									<input type="checkbox" checked> wp_posts
+								</label>
+								<label>
+									<input type="checkbox" checked> wp_postmeta
+								</label>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+
+			<div class="wpcom-migration-section">
+				<button type="submit">Start migration</button>
+			</div>
+		</form>
+	</main>
+
+	<aside class="wpcom-migration-sidebar">
+		<div class="wpcom-migration-sidebar__inner">
+			<h3>What our customers are saying</h3>
+			<p>
+				“After migrating to WordPress.com our site is faster, easier to use, more secure, and technical support is nearly instant.”
+				<br>
+				– Michael P.
+			</p>
+
+			<div class="wpcom-migration-testimonial">
+				<div class="wpcom-migration-testimonial__text">Loved by our customers</div>
+				<img class="wpcom-migration-testimonial__image" src="<?php echo esc_url( plugins_url('../static/assets/images/testimonial.png', __FILE__ ) ); ?>" alt="testimonial" />
+			</div>
+		</div>
+
+		<p>Having trouble? <a href="" target="_blank">Let us take over</a></p>
+	</aside>
+</div>

--- a/src/wp_admin.php
+++ b/src/wp_admin.php
@@ -87,6 +87,14 @@ class WPCOMWPAdmin {
 					[],
 					$this->bvinfo->version
 				);
+
+				wp_enqueue_script(
+					'bvwpcom-static-app',
+					plugins_url( 'static/assets/js/app.js', __FILE__ ),
+					[],
+					$this->bvinfo->version,
+					true
+				);
 			}
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/8724

## Proposed Changes
* Add the main migration details page.
* The checkbox colors will be updated in a separate PR.

## Testing Instructions

1. [Download](https://download-directory.github.io/?url=https%3A%2F%2Fgithub.com%2Fblogvault%2Fwpcom-migration%2Ftree%2Fadd%2Fstatic-details-screen%2Fsrc) and install the plugin. You could use [jurassic.ninja](https://jurassic.ninja/) for a quick environment setup.
2. Go to `/wp-admin/admin.php?page=automattic&static=start`.
3. Compare the page to the [design](https://www.figma.com/design/c9jLiGBEqrxgEpHc8ccVFr/WP.com-migration-plugin-screen-designs?node-id=163-411&t=E27OyiNeJR3nqdoN-0). Having small differences should be fine, IMO.
4. Make sure it looks good on mobile and the different browsers.