### PR TITLE
Added static migration-complete screen

### DIFF
--- a/src/static/migration-complete.php
+++ b/src/static/migration-complete.php
@@ -1,0 +1,36 @@
+<header class="wpcom-migration-header">
+	<div class="wpcom-migration-header__wpcom-logo">
+		<span class="dashicons dashicons-wordpress-alt"></span>
+	</div>
+
+	<div class="wpcom-migration-header__blogvault-logo">
+		<img src="<?php echo esc_url( plugins_url('../assets/img/blogvault-logo.png', __FILE__ ) ); ?>" alt="blogvault-logo">
+	</div>
+</header>
+
+<div class="wpcom-migration-container">
+	<main class="wpcom-migration-content">
+		<h1>Your site has been migrated to WordPress.com</h1>
+		<p>The finish line is close! We’ve emailed you at email@address.com with the final steps to complete the process.</p>
+
+		<p>Take a look at your site and let us know if anything looks off by replying to the email we sent you.</p>
+
+		<form class="wpcom-migration-form">
+			<div class="wpcom-migration-section">
+				<button type="submit">Review your new site</button>
+			</div>
+		</form>
+	</main>
+
+	<aside class="wpcom-migration-sidebar">
+		<div class="wpcom-migration-sidebar__inner">
+			<h3>WordPress, Your Way</h3>
+			<p>You’re ready to experience the best way to WordPress. Lightning-fast hosting, intuitive, flexible editing, and everything you need to grow your site and audience, baked right in.</p>
+
+			<div class="wpcom-migration-testimonial">
+				<div class="wpcom-migration-testimonial__text">Loved by our customers</div>
+				<img class="wpcom-migration-testimonial__image" src="<?php echo esc_url( plugins_url('../static/assets/images/testimonial.png', __FILE__ ) ); ?>" alt="testimonial" />
+			</div>
+		</div>
+	</aside>
+</div>


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/8728

# Screenshots
Desktop:
<img width="1259" alt="CleanShot 2024-08-19 at 13 36 43@2x" src="https://github.com/user-attachments/assets/725455be-df45-4612-b715-5ca2ec50b53e">

Mobile:
<img width="509" alt="CleanShot 2024-08-19 at 13 37 04@2x" src="https://github.com/user-attachments/assets/705914a9-fa17-4287-959a-cb26bbd44dfa">

# Testing Instructions
1. Apply this branch locally or download it as a .zip. You could use [jurassic.ninja](https://jurassic.ninja/) for a quick environment setup.
2. Go to `/wp-admin/admin.php?page=automattic&static=migration-complete`.
3. Compare the page to the [design](https://www.figma.com/design/c9jLiGBEqrxgEpHc8ccVFr/WP.com-migration-plugin-screen-designs?node-id=163-748&t=t84lrNN8epk4W1Bh-0). Having small differences should be fine, IMO.
4. Make sure it looks good on mobile and the different browsers.