### PR TITLE
BlogVault White-labelled plugin: Added migration-cancelled screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 The following urls can be used to access the various static HTML screens implemented by Automattic.
 
 * `/wp-admin/admin.php?page=automattic&static=main`
+* `/wp-admin/admin.php?page=automattic&static=migration-cancelled`
 * `/wp-admin/admin.php?page=automattic&static=migration-progress`
 * `/wp-admin/admin.php?page=automattic&static=migration-complete`
 * `/wp-admin/admin.php?page=automattic&static=start`

--- a/src/static/assets/css/style.css
+++ b/src/static/assets/css/style.css
@@ -331,10 +331,12 @@
 	line-height: 20px;
 }
 
+a.dark-link,
 .wpcom-migration-input-group--checkbox a {
 	color: var( --wpcom-migration-gray-60 );
 }
 
+a.dark-link:hover,
 .wpcom-migration-input-group--checkbox a:hover {
 	text-decoration: none;
 }

--- a/src/static/migration-cancelled.php
+++ b/src/static/migration-cancelled.php
@@ -1,0 +1,40 @@
+<header class="wpcom-migration-header">
+	<div class="wpcom-migration-header__wpcom-logo">
+		<span class="dashicons dashicons-wordpress-alt"></span>
+	</div>
+
+	<div class="wpcom-migration-header__blogvault-logo">
+		Powered by <img src="<?php echo esc_url( plugins_url('../assets/img/blogvault-logo.png', __FILE__ ) ); ?>" alt="blogvault-logo">
+	</div>
+</header>
+
+<div class="wpcom-migration-container">
+	<main class="wpcom-migration-content">
+		<h1>Your migration to WordPress.com has been cancelled</h1>
+		<p>We stopped migrating <strong>sourcesite.url</strong> to WordPress.com. You can try again or <a href="" class="dark-link">contact us</a> if you would like us to do it for you. Our migration service is Free and you'll be up and running in no more than 2 business days.</p>
+
+		<form class="wpcom-migration-form">
+			<div class="wpcom-migration-section">
+				<button type="submit">Restart Migration</button>
+			</div>
+		</form>
+	</main>
+
+	<aside class="wpcom-migration-sidebar">
+		<div class="wpcom-migration-sidebar__inner">
+			<h3>What our customers are saying</h3>
+			<p>
+				“After migrating to WordPress.com our site is faster, easier to use, more secure, and technical support is nearly instant.”
+				<br>
+				– Michael P.
+			</p>
+
+			<div class="wpcom-migration-testimonial">
+				<div class="wpcom-migration-testimonial__text">Loved by our customers</div>
+				<img class="wpcom-migration-testimonial__image" src="<?php echo esc_url( plugins_url('../static/assets/images/testimonial.png', __FILE__ ) ); ?>" alt="testimonial" />
+			</div>
+		</div>
+
+		<p>Having trouble? <a href="" target="_blank">Let us take over</a></p>
+	</aside>
+</div>

--- a/src/static/migration-cancelled.php
+++ b/src/static/migration-cancelled.php
@@ -34,7 +34,5 @@
 				<img class="wpcom-migration-testimonial__image" src="<?php echo esc_url( plugins_url('../static/assets/images/testimonial.png', __FILE__ ) ); ?>" alt="testimonial" />
 			</div>
 		</div>
-
-		<p>Having trouble? <a href="" target="_blank">Let us take over</a></p>
 	</aside>
 </div>


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/8904

# Screenshots

Desktop:

<img width="1275" alt="CleanShot 2024-08-26 at 13 42 44@2x" src="https://github.com/user-attachments/assets/1f717fa1-9562-43ac-af98-feac8a13ffb9">


Mobile:
<img width="494" alt="CleanShot 2024-08-26 at 13 42 56@2x" src="https://github.com/user-attachments/assets/d668c5ee-1165-43c2-a1ee-099119bd5e23">


# Testing Instructions
1. [Download](https://download-directory.github.io/?url=https%3A%2F%2Fgithub.com%2Fblogvault%2Fwpcom-migration%2Ftree%2Fupdate-migration-cancelled-screen) and install the plugin. You could use [jurassic.ninja](https://jurassic.ninja/) for a quick environment setup.
2. Go to `/wp-admin/admin.php?page=automattic&static=migration-cancelled`.
3. Compare the page to the [design](https://www.figma.com/design/c9jLiGBEqrxgEpHc8ccVFr/WP.com-migration-plugin-screen-designs?node-id=163-409&t=ks3l9PQNgzr91l55-0). Having small differences should be fine, IMO.
4. Make sure it looks good on mobile and the different browsers.