### PR TITLE
BlogVault White-labelled plugin: Add JS to show/hide the cancel-migration modal

### DIFF
--- a/src/static/assets/css/style.css
+++ b/src/static/assets/css/style.css
@@ -174,6 +174,15 @@
 	width: 100%;
 	height: 100%;
 }
+.wpcom-migration-modal-container {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+	background-color: rgba(0, 0, 0, 0.6);
+    z-index: 1000;
+}
 .wpcom-migration-modal {
 	background: white;
 	width: 424px;
@@ -184,8 +193,11 @@
 	transform: translate(-50%, -50%);
 }
 #wpbody-content:before,
-.wpcom-migration-modal {
+.wpcom-migration-modal-container {
 	display: none;
+}
+.wpcom-migration-modal-container.wpcom-migration-modal--visible {
+	display: block;
 }
 .wpcom-migration-modal h1 {
 	font-size: 20px;

--- a/src/static/assets/css/style.css
+++ b/src/static/assets/css/style.css
@@ -185,7 +185,8 @@
 }
 .wpcom-migration-modal {
 	background: white;
-	width: 424px;
+	width: 100%;
+	max-width: 424px;
 	z-index: 999;
 	position: absolute;
 	top: 50%;
@@ -213,6 +214,7 @@
 	display: flex;
 	justify-content: space-between;
 	padding: 24px;
+	gap: 16px;
 }
 .wpcom-migration-modal-buttons.wpcom-migration-form button {
 	border-radius: 2px;

--- a/src/static/assets/js/app.js
+++ b/src/static/assets/js/app.js
@@ -1,23 +1,60 @@
-( function () {
-	const toggleFoldable = function ( foldableElement ) {
-		foldableElement.classList.toggle('wpcom-migration-foldable--expanded');
-	}
+(function () {
+  const toggleFoldable = function (foldableElement) {
+    foldableElement.classList.toggle("wpcom-migration-foldable--expanded");
+  };
 
-	const checkInputGroupCheckboxes = function ( inputGroupElement, checked ) {
-		inputGroupElement.querySelectorAll( 'input[type="checkbox"]' ).forEach( ( checkboxElement ) => {
-			checkboxElement.checked = checked;
-		} );
-	}
+  const checkInputGroupCheckboxes = function (inputGroupElement, checked) {
+    inputGroupElement
+      .querySelectorAll('input[type="checkbox"]')
+      .forEach((checkboxElement) => {
+        checkboxElement.checked = checked;
+      });
+  };
 
-	document.querySelectorAll( '.wpcom-migration-foldable__header' ).forEach( ( element ) => {
-		element.addEventListener( 'click', () => toggleFoldable( element.parentElement ) );
-	} );
+  document
+    .querySelectorAll(".wpcom-migration-foldable__header")
+    .forEach((element) => {
+      element.addEventListener("click", () =>
+        toggleFoldable(element.parentElement)
+      );
+    });
 
-	document.querySelectorAll( 'input.wpcom-migration-select-all' ).forEach( ( checkboxElement ) => {
-		checkboxElement.addEventListener( 'change', () => {
-			const inputGroupElement = checkboxElement.closest( '.wpcom-migration-input-group' );
+  document
+    .querySelectorAll("input.wpcom-migration-select-all")
+    .forEach((checkboxElement) => {
+      checkboxElement.addEventListener("change", () => {
+        const inputGroupElement = checkboxElement.closest(
+          ".wpcom-migration-input-group"
+        );
 
-			checkInputGroupCheckboxes( inputGroupElement, checkboxElement.checked );
-		} );
-	} );
-} )();
+        checkInputGroupCheckboxes(inputGroupElement, checkboxElement.checked);
+      });
+    });
+
+  // Display the Cancel Migration modal
+  const cancelButton = document.querySelector(
+    ".wpcom-migration-form button.cancel-migration"
+  );
+  const cancelModal = document.querySelector(
+    ".wpcom-migration-modal-container"
+  );
+  if (cancelButton && cancelModal) {
+    cancelButton.addEventListener("click", (e) => {
+      e.preventDefault();
+
+      cancelModal.classList.add("wpcom-migration-modal--visible");
+    });
+  }
+
+  document
+    .querySelectorAll(
+      ".wpcom-migration-modal .wpcom-migration-modal-buttons > button"
+    )
+    .forEach((element) => {
+      element.addEventListener("click", () => {
+        element
+          .closest(".wpcom-migration-modal-container")
+          .classList.remove("wpcom-migration-modal--visible");
+      });
+    });
+})();

--- a/src/static/migration-cancelled.php
+++ b/src/static/migration-cancelled.php
@@ -1,0 +1,38 @@
+<header class="wpcom-migration-header">
+	<div class="wpcom-migration-header__wpcom-logo">
+		<span class="dashicons dashicons-wordpress-alt"></span>
+	</div>
+
+	<div class="wpcom-migration-header__blogvault-logo">
+		Powered by <img src="<?php echo esc_url( plugins_url('../assets/img/blogvault-logo.png', __FILE__ ) ); ?>" alt="blogvault-logo">
+	</div>
+</header>
+
+<div class="wpcom-migration-container">
+	<main class="wpcom-migration-content">
+		<h1>Your migration to WordPress.com has been cancelled</h1>
+		<p>We stopped migrating <strong>sourcesite.url</strong> to WordPress.com. You can try again or <a href="" class="dark-link">contact us</a> if you would like us to do it for you. Our migration service is Free and you'll be up and running in no more than 2 business days.</p>
+
+		<form class="wpcom-migration-form">
+			<div class="wpcom-migration-section">
+				<button type="submit">Restart Migration</button>
+			</div>
+		</form>
+	</main>
+
+	<aside class="wpcom-migration-sidebar">
+		<div class="wpcom-migration-sidebar__inner">
+			<h3>What our customers are saying</h3>
+			<p>
+				“After migrating to WordPress.com our site is faster, easier to use, more secure, and technical support is nearly instant.”
+				<br>
+				– Michael P.
+			</p>
+
+			<div class="wpcom-migration-testimonial">
+				<div class="wpcom-migration-testimonial__text">Loved by our customers</div>
+				<img class="wpcom-migration-testimonial__image" src="<?php echo esc_url( plugins_url('../static/assets/images/testimonial.png', __FILE__ ) ); ?>" alt="testimonial" />
+			</div>
+		</div>
+	</aside>
+</div>

--- a/src/static/migration-progress.php
+++ b/src/static/migration-progress.php
@@ -52,20 +52,22 @@
 			</div>
 		</div>
 		<div class="wpcom-migration-form">
-			<button class="secondary">
+			<button class="secondary cancel-migration">
 				Cancel migration
 			</button>
 		</div>
 	</div>
 </main>
 
-<div class="wpcom-migration-modal">
-	<div class="wpcom-migration-modal-content">
-		<h1>Cancel migration</h1>
-		<p>If you cancel now, your site won't be migrated to WordPress.com. Are you sure you want to cancel?</p>
-	</div>
-	<div class="wpcom-migration-modal-buttons wpcom-migration-form">
-		<button class="secondary">No, continue migrating</button>
-		<button>Yes, cancel the migration</button>
+<div class="wpcom-migration-modal-container">
+	<div class="wpcom-migration-modal">
+		<div class="wpcom-migration-modal-content">
+			<h1>Cancel migration</h1>
+			<p>If you cancel now, your site won't be migrated to WordPress.com. Are you sure you want to cancel?</p>
+		</div>
+		<div class="wpcom-migration-modal-buttons wpcom-migration-form">
+			<button class="secondary">No, continue migrating</button>
+			<button>Yes, cancel the migration</button>
+		</div>
 	</div>
 </div>


### PR DESCRIPTION
# Screenshots

Desktop:
<img width="1258" alt="CleanShot 2024-08-26 at 14 09 25@2x" src="https://github.com/user-attachments/assets/7b1d0823-29b9-481d-bf71-2b1a55e906c8">


Mobile:
<img width="511" alt="CleanShot 2024-08-26 at 14 09 45@2x" src="https://github.com/user-attachments/assets/ba95cf44-5ef5-4d65-9e3e-65a5da35cdaf">


# Testing Instructions
1. [Download](https://download-directory.github.io/?url=https%3A%2F%2Fgithub.com%2Fblogvault%2Fwpcom-migration%2Ftree%2Fupdate-cancellation-modal) and install the plugin. You could use [jurassic.ninja](https://jurassic.ninja/) for a quick environment setup.
2. Go to `/wp-admin/admin.php?page=automattic&static=migration-progress`.
3. Compare the page to the [design](https://www.figma.com/design/c9jLiGBEqrxgEpHc8ccVFr/WP.com-migration-plugin-screen-designs?node-id=163-409&t=ks3l9PQNgzr91l55-0). Having small differences should be fine, IMO.
4. Make sure it looks good on mobile and the different browsers.